### PR TITLE
Use our own cache timed token instead of the jQuery one

### DIFF
--- a/assets/js/uww.js
+++ b/assets/js/uww.js
@@ -196,10 +196,17 @@
   }
 
   function  ajaxLink(selector, url, callback, context) {
+    // As for the moment we don't receive correct cache headers
+    // let the browser and reverse proxy cache this resource
+    // for a limited time.
+    var ttl = 3*60*1000; // 3min
+    var ts = new Date().getTime();
+    var cacheKey = Math.floor(ts/ttl) * ttl;
+
     var xhr = $.ajax({
       url: url,
       type: "GET",
-      data: "ajax=1",
+      data: "ajax=1&__=" + cacheKey,
 
       success: function (data) {  
         ajaxAfter(context, selector, url, data, window, document);
@@ -213,8 +220,7 @@
       error: function (xhr) {
         //var data = xhr.response.replace("?ajax=1", "");
         ajaxAfter(context, selector, url, data, window, document);
-      },
-      cache: false
+      }
     });
   }
 


### PR DESCRIPTION
This change let the browser and reverse proxy cache the resource for a limited time.

Could be improved by letting this cache strategy configurable with `data attributes`.
For example the video link don't need to be updated as often as results.

/cc @eveyrat 
